### PR TITLE
 added method ts2saxViaWindowGlobalNormalization and bug fixes

### DIFF
--- a/src/main/java/net/seninp/jmotif/sax/SAXProcessor.java
+++ b/src/main/java/net/seninp/jmotif/sax/SAXProcessor.java
@@ -89,7 +89,7 @@ public final class SAXProcessor {
     // create the datastructure
     for (int i = 0; i < currentString.length; i++) {
       char c = currentString[i];
-      saxFrequencyData.add(String.valueOf(c).toCharArray(), i);
+      saxFrequencyData.add(String.valueOf(c).toCharArray(), (int)Math.floor(i*ts.length/currentString.length));
     }
 
     return saxFrequencyData;
@@ -167,6 +167,73 @@ public final class SAXProcessor {
 
   }
 
+  /**
+   * Converts the input time series into a SAX data structure via sliding window and Z
+   * normalization. The difference between this function and ts2saxViaWindow is that in
+   * this function, Z normalization occurs on entire range, rather than the sliding window.
+   * 
+   * @param ts the input data.
+   * @param windowSize the sliding window size.
+   * @param paaSize the PAA size.
+   * @param cuts the Alphabet cuts.
+   * @param nThreshold the normalization threshold value.
+   * @param strategy the NR strategy.
+   * 
+   * @return SAX representation of the time series.
+   * @throws SAXException if error occurs.
+   */
+  public SAXRecords ts2saxViaWindowGlobalNormalization(double[] ts, int windowSize, int paaSize, double[] cuts,
+      NumerosityReductionStrategy strategy, double nThreshold) throws SAXException {
+
+    // the resulting data structure init
+    //
+    SAXRecords saxFrequencyData = new SAXRecords();
+
+    // scan across the time series extract sub sequences, and convert them to strings
+    char[] previousString = null;
+
+    // normalize the entire range
+    double[] normalizedData = tsProcessor.znorm(ts, nThreshold);
+
+    for (int i = 0; i <= ts.length - windowSize; i++) {
+
+      // get the current subsection
+      double[] subSection = Arrays.copyOfRange(normalizedData, i, i + windowSize);
+
+      // perform PAA conversion if needed
+      double[] paa = tsProcessor.paa(subSection, paaSize);
+
+      // Convert the PAA to a string.
+      char[] currentString = tsProcessor.ts2String(paa, cuts);
+
+      if (null != previousString) {
+
+        if (NumerosityReductionStrategy.EXACT.equals(strategy)
+            && Arrays.equals(previousString, currentString)) {
+          // NumerosityReduction
+          continue;
+        }
+        else if (NumerosityReductionStrategy.MINDIST.equals(strategy)
+            && checkMinDistIsZero(previousString, currentString)) {
+          continue;
+        }
+
+      }
+
+      previousString = currentString;
+
+      saxFrequencyData.add(currentString, i);
+    }
+
+    // ArrayList<Integer> keys = saxFrequencyData.getAllIndices();
+    // for (int i : keys) {
+    // System.out.println(i + "," + String.valueOf(saxFrequencyData.getByIndex(i).getPayload()));
+    // }
+
+    return saxFrequencyData;
+
+  }
+  
   /**
    * Converts the input time series into a SAX data structure via sliding window and Z
    * normalization.

--- a/src/main/java/net/seninp/jmotif/sax/SAXProcessor.java
+++ b/src/main/java/net/seninp/jmotif/sax/SAXProcessor.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import org.joda.time.Duration;
@@ -11,7 +12,6 @@ import org.joda.time.format.PeriodFormatter;
 import org.joda.time.format.PeriodFormatterBuilder;
 import net.seninp.jmotif.distance.EuclideanDistance;
 import net.seninp.jmotif.sax.alphabet.NormalAlphabet;
-import net.seninp.jmotif.sax.bitmap.Shingles;
 import net.seninp.jmotif.sax.datastructure.SAXRecord;
 import net.seninp.jmotif.sax.datastructure.SAXRecords;
 
@@ -89,7 +89,8 @@ public final class SAXProcessor {
     // create the datastructure
     for (int i = 0; i < currentString.length; i++) {
       char c = currentString[i];
-      saxFrequencyData.add(String.valueOf(c).toCharArray(), i);
+      saxFrequencyData.add(String.valueOf(c).toCharArray(), (int)Math.floor(i*ts.length/currentString.length));
+      // saxFrequencyData.add(String.valueOf(c).toCharArray(), i);
     }
 
     return saxFrequencyData;
@@ -113,11 +114,6 @@ public final class SAXProcessor {
   public SAXRecords ts2saxViaWindow(double[] ts, int windowSize, int paaSize, double[] cuts,
       NumerosityReductionStrategy strategy, double nThreshold) throws SAXException {
 
-    if (windowSize > ts.length) {
-      throw new SAXException(
-          "Unable to saxify via window, window size is greater than the timeseries length...");
-    }
-
     // the resulting data structure init
     //
     SAXRecords saxFrequencyData = new SAXRecords();
@@ -132,6 +128,73 @@ public final class SAXProcessor {
 
       // Z normalize it
       subSection = tsProcessor.znorm(subSection, nThreshold);
+
+      // perform PAA conversion if needed
+      double[] paa = tsProcessor.paa(subSection, paaSize);
+
+      // Convert the PAA to a string.
+      char[] currentString = tsProcessor.ts2String(paa, cuts);
+
+      if (null != previousString) {
+
+        if (NumerosityReductionStrategy.EXACT.equals(strategy)
+            && Arrays.equals(previousString, currentString)) {
+          // NumerosityReduction
+          continue;
+        }
+        else if (NumerosityReductionStrategy.MINDIST.equals(strategy)
+            && checkMinDistIsZero(previousString, currentString)) {
+          continue;
+        }
+
+      }
+
+      previousString = currentString;
+
+      saxFrequencyData.add(currentString, i);
+    }
+
+    // ArrayList<Integer> keys = saxFrequencyData.getAllIndices();
+    // for (int i : keys) {
+    // System.out.println(i + "," + String.valueOf(saxFrequencyData.getByIndex(i).getPayload()));
+    // }
+
+    return saxFrequencyData;
+
+  }
+
+  /**
+   * Converts the input time series into a SAX data structure via sliding window and Z
+   * normalization. The difference between this function and ts2saxViaWindow is that in
+   * this function, Z normalization occurs on entire range, rather than the sliding window.
+   * 
+   * @param ts the input data.
+   * @param windowSize the sliding window size.
+   * @param paaSize the PAA size.
+   * @param cuts the Alphabet cuts.
+   * @param nThreshold the normalization threshold value.
+   * @param strategy the NR strategy.
+   * 
+   * @return SAX representation of the time series.
+   * @throws SAXException if error occurs.
+   */
+  public SAXRecords ts2saxViaWindowGlobalNormalization(double[] ts, int windowSize, int paaSize, double[] cuts,
+      NumerosityReductionStrategy strategy, double nThreshold) throws SAXException {
+
+    // the resulting data structure init
+    //
+    SAXRecords saxFrequencyData = new SAXRecords();
+
+    // scan across the time series extract sub sequences, and convert them to strings
+    char[] previousString = null;
+
+    // normalize the entire range
+    double[] normalizedData = tsProcessor.znorm(ts, nThreshold);
+
+    for (int i = 0; i <= ts.length - windowSize; i++) {
+
+      // get the current subsection
+      double[] subSection = Arrays.copyOfRange(normalizedData, i, i + windowSize);
 
       // perform PAA conversion if needed
       double[] paa = tsProcessor.paa(subSection, paaSize);
@@ -473,10 +536,9 @@ public final class SAXProcessor {
     // fill in the counts
     for (SAXRecord sr : saxData) {
       String word = String.valueOf(sr.getPayload());
-      int frequency = sr.getIndexes().size();
-      for (int i = 0; i <= word.length() - shingleSize; i++) {
+      for (int i = 0; i < word.length() - shingleSize; i++) {
         String shingle = word.substring(i, i + shingleSize);
-        res.put(shingle, res.get(shingle) + frequency);
+        res.put(shingle, res.get(shingle) + 1);
       }
     }
 
@@ -484,7 +546,7 @@ public final class SAXProcessor {
   }
 
   /**
-   * Converts a time-series data frame into shingled data frame.
+   * Convert a time series into a shingled representation.
    * 
    * @param data the input data.
    * @param windowSize SAX window size.
@@ -492,37 +554,56 @@ public final class SAXProcessor {
    * @param alphabetSize SAX alphabet size.
    * @param strategy SAX NR strategy.
    * @param normalizationThreshold SAX normalization threshold.
-   * @param shingleSize the shingle size.
    * @return shingled representation.
    * @throws SAXException if error occurs.
    */
-  public Shingles manySeriesToShingles(Map<String, ArrayList<double[]>> data, int windowSize,
-      int paaSize, int alphabetSize, NumerosityReductionStrategy strategy,
-      double normalizationThreshold, int shingleSize) throws SAXException {
+  public Map<String, List<double[]>> manySeriesToShingles(Map<String, ArrayList<double[]>> data,
+      int windowSize, int paaSize, int alphabetSize, NumerosityReductionStrategy strategy,
+      double normalizationThreshold) throws SAXException {
 
-    Shingles res = new Shingles(alphabetSize, shingleSize);
+    HashMap<String, List<double[]>> res = new HashMap<String, List<double[]>>();
 
-    // iterate over all training series
+    // build all shingles
+    //
+    String[] alphabet = new String[alphabetSize];
+    for (int i = 0; i < alphabetSize; i++) {
+      alphabet[i] = String.valueOf(TSProcessor.ALPHABET[i]);
+    }
+    String[] allStrings = getAllPermutations(alphabet, paaSize);
+
+    // and make an index table
+    //
+    int len = allStrings.length;
+    HashMap<String, Integer> indexTable = new HashMap<String, Integer>();
+    for (int i = 0; i < allStrings.length; i++) {
+      indexTable.put(allStrings[i], i);
+    }
+
+    // iterate ofer all training series
     //
     for (Entry<String, ArrayList<double[]>> e : data.entrySet()) {
-
       // System.out.println(e.getKey());
       for (double[] series : e.getValue()) {
 
-        // convert the time series into shingles
-        Map<String, Integer> shingles = ts2Shingles(series, windowSize, paaSize, alphabetSize,
-            strategy, normalizationThreshold, shingleSize);
+        // discretize the timeseries
+        SAXRecords saxData = ts2saxViaWindow(series, windowSize, paaSize, na.getCuts(alphabetSize),
+            strategy, normalizationThreshold);
 
-        // allocate the weights array corresponding to the time series
-        int[] counts = new int[res.getIndex().size()];
+        // allocate the weights array corresponding to the timeseries
+        double[] weights = new double[len];
 
         // fill in the counts
-        for (String str : shingles.keySet()) {
-          Integer idx = res.getIndex().get(str);
-          counts[idx] = shingles.get(str);
+        for (SAXRecord sr : saxData) {
+          String word = String.valueOf(sr.getPayload());
+          Integer idx = indexTable.get(word);
+          weights[idx] = sr.getIndexes().size();
         }
 
-        res.addShingledSeries(e.getKey(), counts);
+        // normalize and save that series shingle
+        if (!res.containsKey(e.getKey())) {
+          res.put(e.getKey(), new ArrayList<double[]>());
+        }
+        res.get(e.getKey()).add(tsProcessor.normOne(weights));
 
       }
     }

--- a/src/main/java/net/seninp/jmotif/sax/TSProcessor.java
+++ b/src/main/java/net/seninp/jmotif/sax/TSProcessor.java
@@ -12,8 +12,6 @@ import java.nio.file.Paths;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import net.seninp.jmotif.sax.alphabet.Alphabet;
 
 /**
@@ -29,10 +27,6 @@ public class TSProcessor {
   /** The latin alphabet, lower case letters a-z. */
   public static final char[] ALPHABET = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
       'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
-
-  // static block - we instantiate the logger
-  //
-  private static final Logger LOGGER = LoggerFactory.getLogger(TSProcessor.class);
 
   /**
    * Constructor.
@@ -97,7 +91,7 @@ public class TSProcessor {
         num = Double.valueOf(str);
       }
       catch (NumberFormatException e) {
-        LOGGER.info("Skipping the row " + lineCounter + " with value \"" + str + "\"");
+        // consoleLogger.info("Skipping the row " + lineCounter + " with value \"" + str + "\"");
         continue;
       }
       preRes.add(num);
@@ -281,7 +275,7 @@ public class TSProcessor {
     double mean = mean(series);
     double sd = stDev(series);
     if (sd < normalizationThreshold) {
-      return series.clone();
+      return res;
     }
     for (int i = 0; i < res.length; i++) {
       res[i] = (series[i] - mean) / sd;

--- a/src/main/java/net/seninp/jmotif/sax/TSProcessor.java
+++ b/src/main/java/net/seninp/jmotif/sax/TSProcessor.java
@@ -12,6 +12,8 @@ import java.nio.file.Paths;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import net.seninp.jmotif.sax.alphabet.Alphabet;
 
 /**
@@ -27,6 +29,10 @@ public class TSProcessor {
   /** The latin alphabet, lower case letters a-z. */
   public static final char[] ALPHABET = { 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k',
       'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
+
+  // static block - we instantiate the logger
+  //
+  private static final Logger LOGGER = LoggerFactory.getLogger(TSProcessor.class);
 
   /**
    * Constructor.
@@ -91,7 +97,7 @@ public class TSProcessor {
         num = Double.valueOf(str);
       }
       catch (NumberFormatException e) {
-        // consoleLogger.info("Skipping the row " + lineCounter + " with value \"" + str + "\"");
+        LOGGER.info("Skipping the row " + lineCounter + " with value \"" + str + "\"");
         continue;
       }
       preRes.add(num);
@@ -275,7 +281,7 @@ public class TSProcessor {
     double mean = mean(series);
     double sd = stDev(series);
     if (sd < normalizationThreshold) {
-      return res;
+      return series.clone();
     }
     for (int i = 0; i < res.length; i++) {
       res[i] = (series[i] - mean) / sd;

--- a/src/main/java/net/seninp/jmotif/sax/TSProcessor.java
+++ b/src/main/java/net/seninp/jmotif/sax/TSProcessor.java
@@ -281,7 +281,8 @@ public class TSProcessor {
     double mean = mean(series);
     double sd = stDev(series);
     if (sd < normalizationThreshold) {
-      return series.clone();
+      //return array of zeros
+      return res;
     }
     for (int i = 0; i < res.length; i++) {
       res[i] = (series[i] - mean) / sd;

--- a/src/test/java/net/seninp/jmotif/sax/discord/TestDiscordDiscoveryNONE.java
+++ b/src/test/java/net/seninp/jmotif/sax/discord/TestDiscordDiscoveryNONE.java
@@ -20,7 +20,7 @@ public class TestDiscordDiscoveryNONE {
   private static final int PAA_SIZE = 3;
   private static final int ALPHABET_SIZE = 3;
 
-  private static final double NORM_THRESHOLD = 0.5;
+  private static final double NORM_THRESHOLD = 0.01;
 
   private static final int DISCORDS_TO_TEST = 5;
 


### PR DESCRIPTION
Added a method ts2saxViaWindowGlobalNormalization. It has a clunky name, but it describes the difference. Normalization is performed on the entire time series, before breaking up with the sliding window.

The z-norm did use the normalization threshold, contrary to the comment. However, it returned the original time series, when the more sensible alternative (when running SAX) is to return the zero array.

The change to the test modifies the large normalization threshold to match the threshold used in the other tests. 