### PR TITLE
A small mistake, this parameter should be paaSize

### DIFF
--- a/src/main/java/net/seninp/jmotif/sax/discord/HOTSAXImplementation.java
+++ b/src/main/java/net/seninp/jmotif/sax/discord/HOTSAXImplementation.java
@@ -65,7 +65,7 @@ public class HOTSAXImplementation {
 
     // get the SAX transform done
     NormalAlphabet normalA = new NormalAlphabet();
-    SAXRecords sax = sp.ts2saxViaWindow(series, windowSize, alphabetSize,
+    SAXRecords sax = sp.ts2saxViaWindow(series, windowSize, paaSize,
         normalA.getCuts(alphabetSize), strategy, nThreshold);
     Date saxEnd = new Date();
     LOGGER.debug("discretized in {}, words: {}, indexes: {}",


### PR DESCRIPTION
Today I'm trying to run your HOT-SAX implementation with datasets listed in "http://www.cs.ucr.edu/~eamonn/discords/". But I found that I can't control SAX representation size properly, so I found this small mistake  :  )