### PR TITLE
More appropriate usage of NThreshold

### DIFF
--- a/src/main/java/net/seninp/jmotif/sax/TSProcessor.java
+++ b/src/main/java/net/seninp/jmotif/sax/TSProcessor.java
@@ -271,11 +271,26 @@ public class TSProcessor {
 
   /**
    * Z-Normalize routine.
+   * Single parameter version is for actual distance calculation.
+   * Double parameter version (include normalizationThreshold) is for SAX.
    * 
    * @param series the input timeseries.
    * @param normalizationThreshold the zNormalization threshold value.
    * @return Z-normalized time-series.
    */
+  
+  public double[] znorm(double[] series) {
+    double[] res = new double[series.length];
+    double mean = mean(series);
+    double sd = stDev(series);
+
+    for (int i = 0; i < res.length; i++) {
+      res[i] = (series[i] - mean) / sd;
+    }
+    return res;
+
+  }
+
   public double[] znorm(double[] series, double normalizationThreshold) {
     double[] res = new double[series.length];
     double mean = mean(series);

--- a/src/main/java/net/seninp/jmotif/sax/discord/HOTSAXImplementation.java
+++ b/src/main/java/net/seninp/jmotif/sax/discord/HOTSAXImplementation.java
@@ -233,7 +233,7 @@ public class HOTSAXImplementation {
 
         // fix the current subsequence trace
         double[] currentCandidateSeq = tp
-            .znorm(tp.subseriesByCopy(series, currentPos, currentPos + windowSize), nThreshold);
+            .znorm(tp.subseriesByCopy(series, currentPos, currentPos + windowSize));
 
         // let the search begin ..
         double nearestNeighborDist = Double.MAX_VALUE;
@@ -254,7 +254,7 @@ public class HOTSAXImplementation {
           // nextOccurrence + windowSize);
           // double dist = ed.distance(currentCandidateSeq, occurrenceSubsequence);
           double dist = distance(currentCandidateSeq, series, nextOccurrence,
-              nextOccurrence + windowSize, nThreshold);
+              nextOccurrence + windowSize);
           distanceCalls++;
 
           // keep track of best so far distance
@@ -309,8 +309,7 @@ public class HOTSAXImplementation {
             // double[] randomSubsequence = tp.subseriesByCopy(series, randomPos,
             // randomPos + windowSize);
             // double dist = ed.distance(currentCandidateSeq, randomSubsequence);
-            double dist = distance(currentCandidateSeq, series, randomPos, randomPos + windowSize,
-                nThreshold);
+            double dist = distance(currentCandidateSeq, series, randomPos, randomPos + windowSize);
             distanceCalls++;
 
             // keep track
@@ -668,16 +667,15 @@ public class HOTSAXImplementation {
    * Calculates the Euclidean distance between two points. Don't use this unless you need that.
    * 
    * @param subseries The first subsequence -- ASSUMED TO BE Z-normalized.
-   * @param series The second point.
+   * @param series The second subsequence.
    * @param from the initial index of the range to be copied, inclusive
    * @param to the final index of the range to be copied, exclusive. (This index may lie outside the
    * array.)
    * @param nThreshold z-Normalization threshold.
    * @return The Euclidean distance between z-Normalized versions of subsequences.
    */
-  private static double distance(double[] subseries, double[] series, int from, int to,
-      double nThreshold) throws Exception {
-    double[] subsequence = tp.znorm(tp.subseriesByCopy(series, from, to), nThreshold);
+  private static double distance(double[] subseries, double[] series, int from, int to) throws Exception {
+    double[] subsequence = tp.znorm(tp.subseriesByCopy(series, from, to));
     Double sum = 0D;
     for (int i = 0; i < subseries.length; i++) {
       double tmp = subseries[i] - subsequence[i];


### PR DESCRIPTION
NThreshold (normalization threshold value) can be used in SAX to deal with one special case (normalization to a subsequence which is almost constant) as mentioned in "Experiencing SAX: a novel symbolic representation of time series". It assigns the entire word to the middle-ranged alphabet when the standard deviation of current subsequence is slower than NThreshold.

However, I think it's not appropriate to use it in the z-normalization step when we are going to do actual distance calculations of subsequence pairs. In your implementation, the "znorm" method within class "TSProcessor" will return array of zeros when an input subsequence have a small standard deviation (smaller than NThreshold value like 0.01). By doing so, a subsequence with little fluctuation will be considered as a horizontal straight line, the original information of this subsequence is lost. Then we will get incorrect distance results between subsequences.  

And what if we need to set a higher value of NThreshold under some scenarios? Many subsequences will lose their wave shape information. We will get incorrect distance values and poor discord results.

**In conclusion**, I think using the normalization threshold value in the z-normalization step before creating SAX representation is great for countering extreme cases. If we set unsuitable SAX related parameters, it will only influence the efficiency of HOT-SAX (SAX only influence the heuristic order of outer and inner loop), not the final discord results. But using this value in the z-normalization step before calculating actual distances is bad, because it will distort original information of subsequences and leads to poor results. In this case, if we change the value of NThreshold, we can get different discord results.

Therefore I think it's better to have two versions of "znorm" method for these two different situations. (1. z-normalization for SAX  2. z-normalization for actual distance calculation)

I wish my explanation makes sense to you  : )
